### PR TITLE
scripts/chwd: Prevent removal of base mesa packages

### DIFF
--- a/scripts/chwd
+++ b/scripts/chwd
@@ -44,10 +44,9 @@ local function check_on_multilib()
     end
 end
 
--- https://stackoverflow.com/questions/1426954/split-string-in-lua
-local function split(str, sep)
+local function split(str)
     local t = {}
-    for found in str:gmatch("([^".. sep .."]+)") do
+    for found in str:gmatch("([^%s]+)") do
         t[#t+1] = found
     end
     return t
@@ -89,7 +88,7 @@ local function install(packages)
 end
 
 local function remove(packages)
-    packages = split(packages, " ")
+    packages = split(packages)
 
     local pkgs = ""
     for _, pkg in ipairs(packages) do

--- a/scripts/chwd
+++ b/scripts/chwd
@@ -92,7 +92,7 @@ local function remove(packages)
 
     local pkgs = ""
     for _, pkg in ipairs(packages) do
-        if is_installed(pkg) then
+        if is_installed(pkg) and (pkg ~= "mesa" or pkg ~= "lib32-mesa") then
             pkgs = pkgs .. " " .. pkg
         end
     end


### PR DESCRIPTION
Since we use ``-Rdd`` to avoid various removal conflicts, we must be careful about removing packages such as mesa and lib32-mesa, as they are hard dependencies for most graphics applications. Removing them will break the system. Perhaps instead of such heuristics we should just remove from the profiles, since they will be pulled in by other packages anyway.