### PR TITLE
profiles/nouveau: Drop libva-vdpau-driver

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -102,7 +102,7 @@ nonfree = false
 class_ids = "0300 0302"
 vendor_ids = "10de"
 priority = 0
-packages = 'mesa lib32-mesa libva-mesa-driver mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa lib32-libva-mesa-driver libva-vdpau-driver lib32-libva-vdpau-driver'
+packages = 'mesa lib32-mesa libva-mesa-driver mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa lib32-libva-mesa-driver'
 
 [intel]
 desc = "Mesa open source driver for Intel"


### PR DESCRIPTION
Causes video playback to crash constantly on X11:

```
av:h264:df0[86447]: segfault at d8 ip 00007c51716e8ab4 sp 00007c50dd5f4d18 error 4 in libX11.so.6.4.0[7c51716d9000+8b000] likely on CPU 10 (>
```

Btw, should we really install all these VDPAU drivers if VAAPI is now used everywhere and has practically replaced VDPAU?