### PR TITLE
Add a workaround to fix RTD3 issue on GNOME+PRIME

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -118,6 +118,12 @@ MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
 EOF
     mkinitcpio -P
     systemctl enable switcheroo-control
+
+    # Workaround to fix broken RTD3 on GNOME, which keeps taking up 1MB of VRAM
+    # without letting the dGPU fully sleep or keeping it running for long
+    # periods of time.
+    # See: https://gitlab.gnome.org/GNOME/mutter/-/issues/2969
+    echo "export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json" > /etc/profile.d/nvidia-rt3d-workaround.sh
 """
 post_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf


### PR DESCRIPTION
Workaround to fix broken RTD3 on GNOME, which keeps taking up 1MB of VRAM  without letting the dGPU fully sleep or keeping it running for long periods of time. 
See: https://gitlab.gnome.org/GNOME/mutter/-/issues/2969