### PR TITLE
Replace rusticl with closver-mesa

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -118,7 +118,7 @@ nonfree = false
 class_ids = "0300 0302"
 vendor_ids = "10de"
 priority = 0
-packages = 'mesa lib32-mesa libva-mesa-driver mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa lib32-libva-mesa-driver vulkan-nouveau'
+packages = 'mesa lib32-mesa libva-mesa-driver mesa-vdpau opencl-clover-mesa lib32-opencl-clover-mesa lib32-libva-mesa-driver vulkan-nouveau'
 
 [intel]
 desc = "Mesa open source driver for Intel"
@@ -127,7 +127,7 @@ class_ids = "0300 0302"
 vendor_ids = "8086"
 device_ids = "*"
 priority = 4
-packages = 'mesa lib32-mesa libva-intel-driver lib32-libva-intel-driver opencl-rusticl-mesa lib32-opencl-rusticl-mesa vulkan-intel lib32-vulkan-intel intel-media-driver mesa-vdpau lib32-mesa-vdpau'
+packages = 'mesa lib32-mesa libva-intel-driver lib32-libva-intel-driver opencl-clover-mesa lib32-opencl-clover-mesa vulkan-intel lib32-vulkan-intel intel-media-driver mesa-vdpau lib32-mesa-vdpau'
 
 [amd]
 desc = "Mesa open source driver for AMD"
@@ -136,7 +136,7 @@ class_ids = "0300 0302"
 vendor_ids = "1002"
 device_ids = "*"
 priority = 4
-packages = 'mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
+packages = 'mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-clover-mesa lib32-opencl-clover-mesa'
 
 [fallback]
 desc = 'Fallback profile'


### PR DESCRIPTION
Rusticl seems to break on  Hybrid Laptops CUDA and with it Davinci Resolve and several other applications.

These tools seems to prefer it over cuda and somehow even disables cuda then.

I also remove rocm-opencl-runtime to be safe. We can handle further automatic rocm installation via AI_SDK.