### PR TITLE
nvidia-dkms: Add LIBVA_DRIVER_NAME to profile.d

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -44,6 +44,9 @@ conditional_packages = """
     [ -z "$modules" ] && modules="nvidia-dkms"
 
     echo "$modules"
+
+    # Add libva-nvidia-driver to profile
+    echo "export LIBVA_DRIVER_NAME=nvidia" > /etc/profile.d/nvidia-vaapi.sh
 """
 post_install = """
     cat <<EOF >/etc/mkinitcpio.conf.d/10-chwd.conf
@@ -54,6 +57,7 @@ EOF
 """
 post_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf
+    rm -f /etc/profile.d/nvidia-vaapi.sh
     mkinitcpio -P
 """
 device_ids = '*'

--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -97,6 +97,13 @@ class_ids = "0300 0380"
 vendor_ids = "10de"
 packages = 'nvidia-470xx-dkms nvidia-470xx-utils nvidia-470xx-settings opencl-nvidia-470xx vulkan-icd-loader lib32-nvidia-470xx-utils lib32-opencl-nvidia-470xx lib32-vulkan-icd-loader libva-nvidia-driver'
 device_name_pattern = '(GK)\w+'
+post_install = """
+    # Add libva-nvidia-driver to profile
+    echo "export LIBVA_DRIVER_NAME=nvidia" > /etc/profile.d/nvidia-vaapi.sh
+"""
+post_remove = """
+    rm -f /etc/profile.d/nvidia-vaapi.sh
+"""
 
 [nvidia-dkms-470xx.prime]
 desc = 'Closed source NVIDIA drivers for Linux (470xx branch, only for Kepler GPUs)'

--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -45,8 +45,6 @@ conditional_packages = """
 
     echo "$modules"
 
-    # Add libva-nvidia-driver to profile
-    echo "export LIBVA_DRIVER_NAME=nvidia" > /etc/profile.d/nvidia-vaapi.sh
 """
 post_install = """
     cat <<EOF >/etc/mkinitcpio.conf.d/10-chwd.conf
@@ -54,6 +52,9 @@ post_install = """
 MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
 EOF
     mkinitcpio -P
+
+    # Add libva-nvidia-driver to profile
+    echo "export LIBVA_DRIVER_NAME=nvidia" > /etc/profile.d/nvidia-vaapi.sh
 """
 post_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf


### PR DESCRIPTION
This adds the required configuration for the libva-nvidia-driver.

This makes the VAAPI support working with the direct backend.