### PR TITLE
profiles/graphic_drivers: Make a determination of PRIME profile usage…

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -24,7 +24,7 @@ device_name_pattern = '(AD)\w+'
 [nvidia-dkms]
 desc = 'Closed source NVIDIA drivers for Linux (Latest)'
 nonfree = true
-class_ids = "0300 0380"
+class_ids = "0300 0302 0380"
 vendor_ids = "10de"
 priority = 8
 packages = 'nvidia-utils egl-wayland nvidia-settings opencl-nvidia lib32-opencl-nvidia lib32-nvidia-utils libva-nvidia-driver vulkan-icd-loader lib32-vulkan-icd-loader'
@@ -61,11 +61,12 @@ post_remove = """
     rm -f /etc/profile.d/nvidia-vaapi.sh
     mkinitcpio -P
 """
-device_ids = '*'
+device_name_pattern = "([A-Z]+[0-9]+[^M]*)[[:blank:]].*"
 
 [nvidia-dkms.prime]
 desc = 'Closed source NVIDIA drivers for Linux (Latest)'
-class_ids = "0302"
+class_ids = "0300 0302 0380"
+device_name_pattern = "([A-Z]+[0-9]+[A-Z]*M)[[:blank:]].*"
 priority = 10
 packages = 'nvidia-utils egl-wayland nvidia-settings opencl-nvidia lib32-opencl-nvidia lib32-nvidia-utils libva-nvidia-driver vulkan-icd-loader lib32-vulkan-icd-loader nvidia-prime switcheroo-control'
 post_install = """
@@ -87,7 +88,6 @@ post_remove = """
     rm -f /etc/profile.d/nvidia-rt3d-workaround.sh
     mkinitcpio -P
 """
-device_ids = '*'
 
 [nvidia-dkms-470xx]
 desc = 'Closed source NVIDIA drivers for Linux (470xx branch, only for Kepler GPUs)'


### PR DESCRIPTION
… based on the device name

All (hopefully) NVIDIA mobile card device names contain the suffix `M`, which is the always last character before the expanded device nam, so that way we can determine whether or not there is a dGPU without looking at the class ID. Shouldn't cause the regressions that https://github.com/CachyOS/chwd/commit/cf2e74a4a4d28eb3484dad1b99a460ee8150070e had.