### PR TITLE
nvidia: Drop rt3d workaround, since it does break the wayland KDE

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -71,16 +71,9 @@ MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
 EOF
     mkinitcpio -P
     systemctl enable switcheroo-control
-
-    # Workaround to fix broken RTD3 on GNOME, which keeps taking up 1MB of VRAM
-    # without letting the dGPU fully sleep or keeping it running for long
-    # periods of time.
-    # See: https://gitlab.gnome.org/GNOME/mutter/-/issues/2969
-    echo "export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json" > /etc/profile.d/nvidia-rt3d-workaround.sh
 """
 post_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf
-    rm -f /etc/profile.d/nvidia-rt3d-workaround.sh
     mkinitcpio -P
 """
 
@@ -140,16 +133,9 @@ MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
 EOF
     mkinitcpio -P
     systemctl enable switcheroo-control
-
-    # Workaround to fix broken RTD3 on GNOME, which keeps taking up 1MB of VRAM
-    # without letting the dGPU fully sleep or keeping it running for long
-    # periods of time.
-    # See: https://gitlab.gnome.org/GNOME/mutter/-/issues/2969
-    echo "export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json" > /etc/profile.d/nvidia-rt3d-workaround.sh
 """
 post_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf
-    rm -f /etc/profile.d/nvidia-rt3d-workaround.sh
     mkinitcpio -P
 """
 


### PR DESCRIPTION
An user has reported to us an issue, that going into the wayland KDE session results into a blackscreen.

After debugging with the user, we have tried to remove the RTD3 workaround, since it would be not required for KDE and the issue was solved, KDE session worked without a problem.

The Laptop had following specs:
- AMD Ryzen 7 6800H
- NVIDIA GA106M [GeForce RTX 3060 Mobile / Max-Q]

from lenovo.

If we want to further carry this workaround, we should add a detection, if gnome is used and installed.