### PR TITLE
nvidia: Drop RTD3 Workaround again

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -71,20 +71,9 @@ MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
 EOF
     mkinitcpio -P
     systemctl enable switcheroo-control
-
-    # Workaround to fix broken RTD3 on GNOME, which keeps taking up 1MB of VRAM
-    # without letting the dGPU fully sleep or keeping it running for long
-    # periods of time.
-    # See: https://gitlab.gnome.org/GNOME/mutter/-/issues/2969
-    cat << '\\EOF' >/etc/profile.d/nvidia-rt3d-workaround.sh
-if [ -n "$(lspci -d "10de:*:0302")" ]; then
-    export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
-fi
-EOF
 """
 post_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf
-    rm -f /etc/profile.d/nvidia-rt3d-workaround.sh
     mkinitcpio -P
 """
 
@@ -144,20 +133,9 @@ MODULES+=(nvidia nvidia_modeset nvidia_uvm nvidia_drm)
 EOF
     mkinitcpio -P
     systemctl enable switcheroo-control
-
-    # Workaround to fix broken RTD3 on GNOME, which keeps taking up 1MB of VRAM
-    # without letting the dGPU fully sleep or keeping it running for long
-    # periods of time.
-    # See: https://gitlab.gnome.org/GNOME/mutter/-/issues/2969
-    cat << '\\EOF' >/etc/profile.d/nvidia-rt3d-workaround.sh
-if [ -n "$(lspci -d "10de:*:0302")" ]; then
-    export __EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
-fi
-EOF
 """
 post_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf
-    rm -f /etc/profile.d/nvidia-rt3d-workaround.sh
     mkinitcpio -P
 """
 


### PR DESCRIPTION
The current solution does not fix it for all systems. Lets add a wiki entry about it and keep it out of chwd for now.