### PR TITLE
chwd: Make argument for autoconfigure optional

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -51,7 +51,7 @@ pub struct Args {
     pub list_all: bool,
 
     /// Autoconfigure
-    #[arg(short, long, value_name = "classid", conflicts_with_all(["install", "remove"]))]
+    #[arg(short, long, value_name = "classid", conflicts_with_all(["install", "remove"]), default_missing_value = "any", num_args(0..=1))]
     pub autoconfigure: Option<String>,
 
     /// Toggle AI SDK profiles

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn prepare_autoconfigure(
 
     let mut found_device = false;
     for device in devices.iter() {
-        if device.class_id != autoconf_class_id {
+        if autoconf_class_id != "any" && device.class_id != autoconf_class_id {
             continue;
         }
         found_device = true;
@@ -183,7 +183,9 @@ fn prepare_autoconfigure(
             device.device_name
         );
         if profile.is_none() {
-            log::warn!("No config found for device: {device_info}");
+            if autoconf_class_id != "any" {
+                log::warn!("No config found for device: {device_info}");
+            }
             continue;
         }
         let profile = profile.unwrap();


### PR DESCRIPTION
It allows us to replace install-gpu-drivers script in calamares just by running ``chwd --autoconfigure``.