### PR TITLE
handheld: ally: Replace hhd with inputplumber

### DIFF
--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -97,7 +97,7 @@ vendor_ids = "1002"
 device_ids = "15bf"
 hwd_product_name_pattern = '(ROG Ally).*'
 priority = 6
-packages = 'jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
+packages = 'inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
     username=$(id -nu 1000)

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -100,7 +100,6 @@ priority = 6
 packages = 'inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
-    username=$(id -nu 1000)
     services=("inputplumber")
     maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
     echo "Enabling services..."
@@ -114,7 +113,6 @@ post_install = """
 """
 post_remove = """
     echo "Ally chwd removing..."
-    username=$(id -nu 1000)
     services=("inputplumber")
     maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
     echo "Disabling services..."

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -97,11 +97,11 @@ vendor_ids = "1002"
 device_ids = "15bf"
 hwd_product_name_pattern = '(ROG Ally).*'
 priority = 6
-packages = 'hhd hhd-ui adjustor jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
+packages = 'jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon libva-mesa-driver lib32-libva-mesa-driver mesa-vdpau lib32-mesa-vdpau opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
     username=$(id -nu 1000)
-    services=("hhd@${username}")
+    services=("inputplumber")
     maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
     echo "Enabling services..."
     for service in ${services[@]}; do
@@ -115,7 +115,7 @@ post_install = """
 post_remove = """
     echo "Ally chwd removing..."
     username=$(id -nu 1000)
-    services=("hhd@${username}")
+    services=("inputplumber")
     maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
     echo "Disabling services..."
     for service in ${services[@]}; do


### PR DESCRIPTION
HHD has shown quite difficulty to work on the Ally and Ally X, when the upcoming kernel patches are used.
Generally, having it in the kernel space and using inputplumber on top should provide a better expierence for Ally and Ally X users.

Therefore drop hhd in favor of inputplumber.

The default configuration with inputplumber works OOB but can be further adjusted by the user in its config.