### PR TITLE
profiles/graphic_drivers: Enable nvidia-powerd by default for Ampere+ dGPUs

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -57,6 +57,10 @@ EOF
     # Trying to determine the laptop
     device_type="$(cat /sys/devices/virtual/dmi/id/chassis_type)"
     if ((device_type >= 8 && device_type <= 11)); then
+        # nvidia-powerd is not supported by Turing GPUs
+        if ! lspci -d "10de:*:030x" -vm | grep -q 'Device:\tTU.*'; then
+            systemctl enable nvidia-powerd
+        fi
         systemctl enable switcheroo-control
     else
         # Add libva-nvidia-driver to profile


### PR DESCRIPTION
nvidia-powerd service provides Dynamic Boost technology on laptops with Ampere GPUs and above, this partially unlocks the maximum TDP of dGPU. In my case on the 3050 Mobile, this raises the limit from 35W to 40W, while not causing much change in GPU temperature. This improves performance in Furmark by about ~10 FPS.

Without nvidia-powerd

![image](https://github.com/user-attachments/assets/3f0d9843-4a3e-4a17-bb5c-c332bea31a97)

With nvidia-powerd

![image](https://github.com/user-attachments/assets/6d82b4c5-cc6b-41f8-b744-7500fa298957)

Haven't observed any regressions yet, but testing is welcome.