### PR TITLE
profiles/graphic_drivers: Add rusticl variable for user services

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -181,10 +181,13 @@ post_install = """
 if [ -z "$(lspci -d "10de:*:030x")" ]; then
     # Force the use of Rusticl, otherwise it will be just a stub
     echo "export RUSTICL_ENABLE=nouveau" > /etc/profile.d/opencl.sh
+    mkdir -p /etc/environment.d
+    echo "RUSTICL_ENABLE=nouveau" > /etc/environment.d/30-opencl.conf
 fi
 """
 post_remove = """
 rm -f /etc/profile.d/opencl.sh
+rm -f /etc/environment.d/30-opencl.conf
 """
 
 [intel]
@@ -203,10 +206,13 @@ post_install = """
 if [ -z "$(lspci -d "10de:*:030x")" ]; then
     # Force the use of Rusticl, otherwise it will be just a stub
     echo "export RUSTICL_ENABLE=iris" > /etc/profile.d/opencl.sh
+    mkdir -p /etc/environment.d
+    echo "RUSTICL_ENABLE=iris" > /etc/environment.d/30-opencl.conf
 fi
 """
 post_remove = """
 rm -f /etc/profile.d/opencl.sh
+rm -f /etc/environment.d/30-opencl.conf
 """
 
 [amd]
@@ -225,10 +231,13 @@ post_install = """
 if [ -z "$(lspci -d "10de:*:030x")" ]; then
     # Force the use of Rusticl, otherwise it will be just a stub
     echo "export RUSTICL_ENABLE=radeonsi" > /etc/profile.d/opencl.sh
+    mkdir -p /etc/environment.d
+    echo "RUSTICL_ENABLE=radeonsi" > /etc/environment.d/30-opencl.conf
 fi
 """
 post_remove = """
 rm -f /etc/profile.d/opencl.sh
+rm -f /etc/environment.d/30-opencl.conf
 """
 
 [fallback]


### PR DESCRIPTION
Sad thing: Applications that running in GNOME or KDE do that as systemd user services, which don't inherit shell environment.