### PR TITLE
scripts/chwd: Fix issues with escaping when executing hooks

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -58,7 +58,7 @@ post_install = """
     device_type="$(cat /sys/devices/virtual/dmi/id/chassis_type)"
     if ((device_type >= 8 && device_type <= 11)); then
         # nvidia-powerd is not supported by Turing GPUs
-        if ! lspci -d "10de:*:030x" -vm | grep -q 'Device:\tTU.*'; then
+        if ! lspci -d "10de:*:030x" -vm | grep -q 'Device:\\tTU.*'; then
             systemctl enable nvidia-powerd
         fi
         systemctl enable switcheroo-control
@@ -99,7 +99,7 @@ conditional_packages = """
 
     # Trying to determine the laptop
     device_type="$(cat /sys/devices/virtual/dmi/id/chassis_type)"
-    if [[ "$device_type" -ge 8 && "$device_type" -le 11 ]]; then
+    if ((device_type >= 8 && device_type <= 11)); then
         packages+=" nvidia-prime switcheroo-control"
     fi
 
@@ -258,14 +258,14 @@ device_ids = "*"
 priority = 5
 packages = 'virtualbox-guest-utils xf86-video-vmware open-vm-tools xf86-input-vmmouse spice-vdagent qemu-guest-agent vulkan-virtio gtkmm3'
 post_install = """
-    if [[ "$(systemd-detect-virt)" == "oracle" ]]; then
+    if [ "$(systemd-detect-virt)" = "oracle" ]; then
         # Virtualbox detected
 
         # Load kernel modules and sync clock
         systemctl enable --now --no-block vboxservice.service
     else
 
-        if [[ "$(systemd-detect-virt)" == "vmware" ]]; then
+        if [ "$(systemd-detect-virt)" = "vmware" ]; then
             # Vmware detected
             systemctl enable --now --no-block vmtoolsd.service
         else
@@ -276,17 +276,17 @@ EOF
             mkinitcpio -P
         fi
     fi
-    if [[ -e /etc/gdm/custom.conf ]]; then
+    if [ -e /etc/gdm/custom.conf ]; then
         sed -i -e 's|#WaylandEnable=false|WaylandEnable=false|g' /etc/gdm/custom.conf
     fi"""
 pre_remove = """
     rm -f /etc/mkinitcpio.conf.d/10-chwd.conf
 """
 post_remove = """
-    if [[ "$(systemd-detect-virt)" == "oracle" ]]; then
+    if [ "$(systemd-detect-virt)" = "oracle" ]; then
         # Virtualbox detected
         systemctl disable --now vboxservice.service
-    elif [[ "$(systemd-detect-virt)" == "vmware" ]]; then
+    elif [ "$(systemd-detect-virt)" = "vmware" ]; then
         # Vmware detected
         systemctl disable --now vmtoolsd.service
     fi"""

--- a/scripts/chwd
+++ b/scripts/chwd
@@ -18,8 +18,12 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 --]]
 local pacman, pmconfig, pmroot, cachedir, sync
 
+local function printf(s, ...)
+    print(s:format(...))
+end
+
 local function die(err, ...)
-    print(err:format(...))
+    printf(err, ...)
     os.exit(1)
 end
 
@@ -118,23 +122,33 @@ local function remove(packages)
     end
 end
 
-local function exec_hook(hook)
+local function exec_hook(name, hooks)
+    local hook = hooks[name]
+
     if not hook then
         print("WARNING: An unknown hook is being called")
         return
     end
 
-    if hook ~= "" then
-        local handle, errmsg = io.popen(("/bin/bash -c '%s'"):format(hook), "r")
-
-        if handle then
-            local output = handle:read('*all')
-            handle:close()
-            return output
-        else
-            print(("ERROR: Unkown shell invocation error for %s hook: %s"):format(hook, errmsg))
-        end
+    if hook == "" then
+        return
     end
+
+    local handle, errmsg = io.popen(hook, "r")
+
+    if not handle then
+        printf("ERROR: Unknown shell invocation error for %s hook: %s", name, errmsg)
+        return
+    end
+
+    local output = handle:read("*a")
+    local success, _, exitcode = handle:close()
+
+    if not success then
+        printf("ERROR: Error occurred while executing %s hook: %s", name, exitcode)
+    end
+
+    return output
 end
 
 local function escape_pattern(text)
@@ -279,9 +293,9 @@ local function main()
     end
 
     if options.install then
-        exec_hook(hooks.pre_install)
+        exec_hook(hooks, "pre_install")
 
-        local conditional_packages = exec_hook(hooks.conditional_packages)
+        local conditional_packages = exec_hook(hooks, "conditional_packages")
 
         if conditional_packages then
             packages = packages .. " " .. conditional_packages
@@ -289,15 +303,15 @@ local function main()
 
         local code = install(packages)
         if code ~= 0 then
-            exec_hook(hooks.pre_remove)
+            exec_hook(hooks, "pre_remove")
             die("ERROR: Pacman command was failed! Exit code: %s", code)
         else
-            exec_hook(hooks.post_install)
+            exec_hook(hooks, "post_install")
         end
     elseif options.remove then
-        exec_hook(hooks.pre_remove)
+        exec_hook(hooks, "pre_remove")
 
-        local conditional_packages = exec_hook(hooks.conditional_packages)
+        local conditional_packages = exec_hook(hooks, "conditional_packages")
 
         if conditional_packages then
             packages = packages .. " " .. conditional_packages
@@ -307,7 +321,7 @@ local function main()
         if code ~= 0 then
             die("ERROR: Pacman command was failed! Exit code: %s", code)
         else
-            exec_hook(hooks.post_remove)
+            exec_hook(hooks, "post_remove")
         end
     else
         die("Action is missing, exit...")


### PR DESCRIPTION
Inlining the `/bin/bash` call along with the `-c` key causes escaping issues and is just unnecessary because `popen` call already works within the system shell (`/bin/sh`, although it doesn't seem to prevent bashanisms from being called, but I did bring the hooks to a uniform POSIX-style). 

Should help fix issues that were earlier with the hook for RTD3 and make it easier to test for these kinds of bugs.