### PR TITLE
profiles/handheld: Use Valve's powerbuttond on the ROG Ally

### DIFF
--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -30,7 +30,7 @@ vendor_ids = "1002"
 device_ids = "1435 163f"
 hwd_product_name_pattern = '(Jupiter)'
 priority = 6
-packages = 'powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+packages = 'steamos-powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Steam Deck Jupiter chwd installing..."
     username=$(id -nu 1000)
@@ -63,7 +63,7 @@ vendor_ids = "1002"
 device_ids = "1435 163f"
 hwd_product_name_pattern = '(Galileo)'
 priority = 6
-packages = 'powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+packages = 'steamos-powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 #fbcon=vc:2-6 is not added here because it is added for all devices using calamares.
 post_install = """
     echo "Steam Deck Galileo chwd installing..."

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -97,10 +97,10 @@ vendor_ids = "1002"
 device_ids = "15bf"
 hwd_product_name_pattern = '(ROG Ally).*'
 priority = 6
-packages = 'steam-powerbuttond-git inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+packages = 'steamos-powerbuttond inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
-    services=("inputplumber" "inputplumber-suspend" "steam-powerbuttond")
+    services=("inputplumber" "inputplumber-suspend")
     maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
     echo "Enabling services..."
     for service in ${services[@]}; do

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -100,12 +100,7 @@ priority = 6
 packages = 'steamos-powerbuttond inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
-    services=("inputplumber" "inputplumber-suspend")
     maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
-    echo "Enabling services..."
-    for service in ${services[@]}; do
-        systemctl enable --now "${service}.service"
-    done
     echo "Masking potentially conflicting services"
     for mask in ${maskservices[@]}; do
         systemctl mask "${mask}.service"
@@ -124,12 +119,7 @@ post_install = """
 """
 post_remove = """
     echo "Ally chwd removing..."
-    services=("inputplumber" "inputplumber-suspend")
     maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
-    echo "Disabling services..."
-    for service in ${services[@]}; do
-        systemctl disable "${service}.service"
-    done
     echo "Unmasking potentially conflicting services"
     for mask in ${maskservices[@]}; do
         systemctl unmask "${mask}.service"


### PR DESCRIPTION
During extensive testing with @Froggyman-kashee, it has been confirmed that powerbuttond also works for the Ally. Use that instead of steam-powerbuttond-git.