### PR TITLE
profiles: Replace mesa opencl packages with opencl-mesa

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -229,7 +229,7 @@ priority = 18
 packages = 'mesa lib32-mesa vulkan-nouveau'
 conditional_packages = """
 if [ -z "$(lspci -d "10de:*:030x")" ]; then
-    echo "opencl-rusticl-mesa lib32-opencl-rusticl-mesa"
+    echo "opencl-mesa lib32-opencl-mesa"
 fi
 """
 post_install = """
@@ -255,7 +255,7 @@ packages = 'mesa lib32-mesa vulkan-intel lib32-vulkan-intel gst-plugin-va'
 conditional_packages = """
 pkgs=""
 if [ -z "$(lspci -d "10de:*:030x")" ]; then
-    pkgs+="opencl-rusticl-mesa lib32-opencl-rusticl-mesa"
+    pkgs+="opencl-mesa lib32-opencl-mesa"
 fi
 
 device_id="$(lspci -d "8086:*:030x" -n | cut -d" " -f3 | cut -d":" -f2 | head -n1)"
@@ -289,7 +289,7 @@ priority = 4
 packages = 'mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon xf86-video-amdgpu gst-plugin-va'
 conditional_packages = """
 if [ -z "$(lspci -d "10de:*:030x")" ]; then
-    echo "opencl-rusticl-mesa lib32-opencl-rusticl-mesa"
+    echo "opencl-mesa lib32-opencl-mesa"
 fi
 """
 post_install = """

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -30,7 +30,7 @@ vendor_ids = "1002"
 device_ids = "1435 163f"
 hwd_product_name_pattern = '(Jupiter)'
 priority = 6
-packages = 'powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
+packages = 'powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Steam Deck Jupiter chwd installing..."
     username=$(id -nu 1000)
@@ -63,7 +63,7 @@ vendor_ids = "1002"
 device_ids = "1435 163f"
 hwd_product_name_pattern = '(Galileo)'
 priority = 6
-packages = 'powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
+packages = 'powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 #fbcon=vc:2-6 is not added here because it is added for all devices using calamares.
 post_install = """
     echo "Steam Deck Galileo chwd installing..."
@@ -97,7 +97,7 @@ vendor_ids = "1002"
 device_ids = "15bf"
 hwd_product_name_pattern = '(ROG Ally).*'
 priority = 6
-packages = 'steam-powerbuttond-git inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
+packages = 'steam-powerbuttond-git inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
     services=("inputplumber" "inputplumber-suspend" "steam-powerbuttond")
@@ -146,7 +146,7 @@ vendor_ids = "1002"
 device_ids = "15bf"
 hwd_product_name_pattern = '(83E1)'
 priority = 6
-packages = 'hhd hhd-ui adjustor jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime'
+packages = 'hhd hhd-ui adjustor jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Legion go chwd installing..."
     username=$(id -nu 1000)

--- a/tests/profiles/multiple-profile-raw-escaped-strings-test-parsed.toml
+++ b/tests/profiles/multiple-profile-raw-escaped-strings-test-parsed.toml
@@ -5,7 +5,7 @@ desc = "Test profile"
 device_ids = "1435 163f"
 device_name_pattern = '(AD)\w+'
 hwd_product_name_pattern = '(Ally)\w+'
-packages = "opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime"
+packages = "opencl-mesa lib32-opencl-mesa rocm-opencl-runtime"
 post_install = '''
     echo "Steam Deck chwd installing..."
 '''
@@ -22,7 +22,7 @@ desc = "Test profile"
 device_ids = "1432"
 device_name_pattern = '(ADW)\w+'
 hwd_product_name_pattern = '(AllyX)\w+'
-packages = "opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime mesa"
+packages = "opencl-mesa lib32-opencl-mesa rocm-opencl-runtime mesa"
 post_install = '''
     echo "Test installing..."
 '''

--- a/tests/profiles/multiple-profile-raw-escaped-strings-test.toml
+++ b/tests/profiles/multiple-profile-raw-escaped-strings-test.toml
@@ -7,7 +7,7 @@ desc = "Test profile"
 device_ids = "1435 163f"
 device_name_pattern = '(AD)\w+'
 hwd_product_name_pattern = '(Ally)\w+'
-packages = "opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime"
+packages = "opencl-mesa lib32-opencl-mesa rocm-opencl-runtime"
 post_install = '''
     echo "Steam Deck chwd installing..."
 '''
@@ -21,7 +21,7 @@ vendor_ids = "1002"
 device_ids = "1432"
 device_name_pattern = '(ADW)\w+'
 hwd_product_name_pattern = '(AllyX)\w+'
-packages = "opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime mesa"
+packages = "opencl-mesa lib32-opencl-mesa rocm-opencl-runtime mesa"
 post_install = '''
     echo "Test installing..."
 '''

--- a/tests/profiles/profile-raw-escaped-strings-test.toml
+++ b/tests/profiles/profile-raw-escaped-strings-test.toml
@@ -5,7 +5,7 @@ desc = "Test profile"
 device_ids = "1435 163f"
 device_name_pattern = '(AD)\w+'
 hwd_product_name_pattern = '(Ally)\w+'
-packages = "opencl-rusticl-mesa lib32-opencl-rusticl-mesa rocm-opencl-runtime"
+packages = "opencl-mesa lib32-opencl-mesa rocm-opencl-runtime"
 post_install = '''
     echo "Steam Deck chwd installing..."
     username=$(id -nu 1000)


### PR DESCRIPTION
Mesa 25.1.0 deprecated opencl-clover in favour of rustictl. This now means that the previous opencl packages have essentially been "merged" into `opencl-mesa` package.

Find and replace all instances of opencl-rusticl-mesa to opencl-mesa