### PR TITLE
Handheld Profiles Additions

### DIFF
--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -33,27 +33,19 @@ priority = 6
 packages = 'steamos-powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Steam Deck Jupiter chwd installing..."
-    username=$(id -nu 1000)
     services=("jupiter-fan-control")
     echo "Enabling services..."
     for service in ${services[@]}; do
         systemctl enable --now "${service}.service"
     done
-    #kernelparams="amd_iommu=off amdgpu.gttsize=8128 spi_amd.speed_dev=1 audit=0 iomem=relaxed amdgpu.ppfeaturemask=0xffffffff"
-    #echo "Adding required kernel parameters..."
-    #sed -i "s/LINUX_OPTIONS=\"[^\"]*/& ${kernelparams}/" /etc/sdboot-manage.conf
 """
 post_remove = """
     echo "Steam deck Jupiter chwd removing..."
-    username=$(id -nu 1000)
     services=("jupiter-fan-control")
     echo "Disabling services..."
     for service in ${services[@]}; do
         systemctl disable "${service}.service"
     done
-    #kernelparams="amd_iommu=off amdgpu.gttsize=8128 spi_amd.speed_dev=1 audit=0 iomem=relaxed amdgpu.ppfeaturemask=0xffffffff"
-    #echo "Removing kernel parameters..."
-    #sed -i "s/${kernelparams}//" /etc/sdboot-manage.conf
 """
 
 [steam-deck-galileo]
@@ -67,27 +59,19 @@ packages = 'steamos-powerbuttond jupiter-hw-support jupiter-fan-control steamdec
 #fbcon=vc:2-6 is not added here because it is added for all devices using calamares.
 post_install = """
     echo "Steam Deck Galileo chwd installing..."
-    username=$(id -nu 1000)
     services=("jupiter-fan-control")
     echo "Enabling services..."
     for service in ${services[@]}; do
         systemctl enable --now "${service}.service"
     done
-    #kernelparams="amd_iommu=off amdgpu.gttsize=8128 spi_amd.speed_dev=1 audit=0 iomem=relaxed amdgpu.ppfeaturemask=0xffffffff"
-    #echo "Adding required kernel parameters..."
-    #sed -i "s/LINUX_OPTIONS=\"[^\"]*/& ${kernelparams}/" /etc/sdboot-manage.conf
 """
 post_remove = """
     echo "Steam deck Galileo chwd removing..."
-    username=$(id -nu 1000)
     services=("jupiter-fan-control")
     echo "Disabling services..."
     for service in ${services[@]}; do
         systemctl disable "${service}.service"
     done
-    #kernelparams="amd_iommu=off amdgpu.gttsize=8128 spi_amd.speed_dev=1 audit=0 iomem=relaxed amdgpu.ppfeaturemask=0xffffffff"
-    #echo "Removing kernel parameters..."
-    #sed -i "s/${kernelparams}//" /etc/sdboot-manage.conf
 """
 
 [phoenix-rog-ally]

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -100,11 +100,6 @@ priority = 6
 packages = 'steamos-powerbuttond inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
-    maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
-    echo "Masking potentially conflicting services"
-    for mask in ${maskservices[@]}; do
-        systemctl mask "${mask}.service"
-    done
     echo "Installing audio profile..."
     product_name="$(cat /sys/devices/virtual/dmi/id/product_name)"
     mkdir -p /etc/pipewire/pipewire.conf.d /etc/wireplumber/wireplumber.conf.d/
@@ -122,11 +117,6 @@ post_install = """
 """
 post_remove = """
     echo "Ally chwd removing..."
-    maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
-    echo "Unmasking potentially conflicting services"
-    for mask in ${maskservices[@]}; do
-        systemctl unmask "${mask}.service"
-    done
     echo "Removing audio profile..."
     rm -f /etc/pipewire/pipewire.conf.d/filter-chain.conf
     rm -f /etc/wireplumber/wireplumber.conf.d/alsa-card0{,-x}.conf
@@ -145,14 +135,9 @@ post_install = """
     echo "Legion go chwd installing..."
     username=$(id -nu 1000)
     services=("hhd@${username}")
-    maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
     echo "Enabling services..."
     for service in ${services[@]}; do
         systemctl enable --now "${service}.service"
-    done
-    echo "Masking potentially conflicting services"
-    for mask in ${maskservices[@]}; do
-        systemctl mask "${mask}.service"
     done
     echo "Installing audio profile..."
     mkdir -p /etc/pipewire/pipewire.conf.d /etc/wireplumber/wireplumber.conf.d
@@ -167,14 +152,9 @@ post_remove = """
     echo "Legion go chwd removing..."
     username=$(id -nu 1000)
     services=("hhd@${username}")
-    maskservices=("jupiter-biosupdate" "jupiter-controller-update" "jupiter-fan-control")
     echo "Disabling services..."
     for service in ${services[@]}; do
         systemctl disable "${service}.service"
-    done
-    echo "Unmasking potentially conflicting services"
-    for mask in ${maskservices[@]}; do
-        systemctl unmask "${mask}.service"
     done
     echo "Removing audio profile.."
     rm -f /etc/pipewire/pipewire.conf.d/filter-chain.conf

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -1,28 +1,3 @@
-#Steam Deck's
-#CLASSIDS=0300
-#VENDORIDS=1002
-#DEVICEIDS=1435 (oled), 163f (lcd)
-#Galileo (OLED)
-#Jupiter (LCD)
-
-#ASUS Rog Ally
-#CLASSIDS=0300
-#VENDORIDS=1002
-#DEVICEIDS=15bf
-#ROG Ally RC71L
-
-#ASUS Rog Ally X
-#CLASSIDS=0300
-#VENDORIDS=1002
-#DEVICEIDS=15bf
-#ROG Ally X RC72LA_RC72LA
-
-#Lenovo Legion GO APU
-#CLASSIDS=0300
-#VENDORIDS=1002
-#DEVICEIDS=15bf
-#83E1
-
 [steam-deck-jupiter]
 desc = 'Valve Steam Deck LCD'
 class_ids = "0300"
@@ -56,7 +31,6 @@ device_ids = "1435 163f"
 hwd_product_name_pattern = '(Galileo)'
 priority = 6
 packages = 'steamos-powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
-#fbcon=vc:2-6 is not added here because it is added for all devices using calamares.
 post_install = """
     echo "Steam Deck Galileo chwd installing..."
     services=("jupiter-fan-control")

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -5,7 +5,7 @@ vendor_ids = "1002"
 device_ids = "1435 163f"
 hwd_product_name_pattern = '(Jupiter|Galileo)'
 priority = 6
-packages = 'steamos-powerbuttond jupiter-fan-control steamdeck-dsp cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+packages = 'steamos-manager steamos-powerbuttond jupiter-fan-control steamdeck-dsp cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Steam Deck chwd installing..."
     services=("jupiter-fan-control")
@@ -30,7 +30,7 @@ vendor_ids = "1002"
 device_ids = "15bf 15c8"
 hwd_product_name_pattern = '(ROG Ally).*'
 priority = 6
-packages = 'steamos-powerbuttond inputplumber cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+packages = 'steamos-manager steamos-powerbuttond inputplumber cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
     echo "Installing audio profile..."

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -5,7 +5,7 @@ vendor_ids = "1002"
 device_ids = "1435 163f"
 hwd_product_name_pattern = '(Jupiter|Galileo)'
 priority = 6
-packages = 'steamos-powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+packages = 'steamos-powerbuttond jupiter-fan-control steamdeck-dsp cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Steam Deck chwd installing..."
     services=("jupiter-fan-control")
@@ -30,7 +30,7 @@ vendor_ids = "1002"
 device_ids = "15bf 15c8"
 hwd_product_name_pattern = '(ROG Ally).*'
 priority = 6
-packages = 'steamos-powerbuttond inputplumber jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+packages = 'steamos-powerbuttond inputplumber cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Ally chwd installing..."
     echo "Installing audio profile..."
@@ -63,7 +63,7 @@ vendor_ids = "1002"
 device_ids = "15bf"
 hwd_product_name_pattern = '(83E1)'
 priority = 6
-packages = 'hhd hhd-ui adjustor jupiter-hw-support steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+packages = 'hhd hhd-ui adjustor cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
     echo "Legion go chwd installing..."
     username=$(id -nu 1000)

--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -1,13 +1,13 @@
-[steam-deck-jupiter]
-desc = 'Valve Steam Deck LCD'
+[vangogh-steam-deck]
+desc = 'Valve Steam Deck'
 class_ids = "0300"
 vendor_ids = "1002"
 device_ids = "1435 163f"
-hwd_product_name_pattern = '(Jupiter)'
+hwd_product_name_pattern = '(Jupiter|Galileo)'
 priority = 6
 packages = 'steamos-powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
 post_install = """
-    echo "Steam Deck Jupiter chwd installing..."
+    echo "Steam Deck chwd installing..."
     services=("jupiter-fan-control")
     echo "Enabling services..."
     for service in ${services[@]}; do
@@ -15,32 +15,7 @@ post_install = """
     done
 """
 post_remove = """
-    echo "Steam deck Jupiter chwd removing..."
-    services=("jupiter-fan-control")
-    echo "Disabling services..."
-    for service in ${services[@]}; do
-        systemctl disable "${service}.service"
-    done
-"""
-
-[steam-deck-galileo]
-desc = 'Valve Steam Deck OLED'
-class_ids = "0300"
-vendor_ids = "1002"
-device_ids = "1435 163f"
-hwd_product_name_pattern = '(Galileo)'
-priority = 6
-packages = 'steamos-powerbuttond jupiter-hw-support jupiter-fan-control steamdeck-dsp steam cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
-post_install = """
-    echo "Steam Deck Galileo chwd installing..."
-    services=("jupiter-fan-control")
-    echo "Enabling services..."
-    for service in ${services[@]}; do
-        systemctl enable --now "${service}.service"
-    done
-"""
-post_remove = """
-    echo "Steam deck Galileo chwd removing..."
+    echo "Steam Deck chwd removing..."
     services=("jupiter-fan-control")
     echo "Disabling services..."
     for service in ${services[@]}; do


### PR DESCRIPTION
This PR merges the two Steam Deck profiles into one and adds `steamos-manager` to the list of packages to install for the Steam Deck and ROG Ally. Additionally, unused comments and lines in the post script are removed too for a cleaner file.