### PR TITLE
profile: Retain missing fields in local profile

### DIFF
--- a/src/profile.rs
+++ b/src/profile.rs
@@ -40,6 +40,9 @@ pub struct Profile {
     pub packages: String,
     pub post_install: String,
     pub post_remove: String,
+    pub pre_install: String,
+    pub pre_remove: String,
+    pub conditional_packages: String,
     pub device_name_pattern: Option<String>,
     pub hwd_product_name_pattern: Option<String>,
     pub gc_versions: Option<Vec<String>>,
@@ -204,6 +207,9 @@ fn parse_profile(node: &toml::Table, profile_name: &str) -> Result<Profile> {
         packages: node.get("packages").and_then(|x| x.as_str()).unwrap_or("").to_owned(),
         post_install: node.get("post_install").and_then(|x| x.as_str()).unwrap_or("").to_owned(),
         post_remove: node.get("post_remove").and_then(|x| x.as_str()).unwrap_or("").to_owned(),
+        pre_install: node.get("pre_install").and_then(|x| x.as_str()).unwrap_or("").to_owned(),
+        pre_remove: node.get("pre_remove").and_then(|x| x.as_str()).unwrap_or("").to_owned(),
+        conditional_packages: node.get("conditional_packages").and_then(|x| x.as_str()).unwrap_or("").to_owned(),
         desc: node.get("desc").and_then(|x| x.as_str()).unwrap_or("").to_owned(),
         priority: node.get("priority").and_then(|x| x.as_integer()).unwrap_or(0) as i32,
         hwd_ids: vec![Default::default()],
@@ -381,6 +387,15 @@ fn profile_into_toml(profile: &Profile) -> toml::Table {
     if !profile.post_remove.is_empty() {
         table.insert("post_remove".to_owned(), profile.post_remove.clone().into());
     }
+    if !profile.pre_install.is_empty() {
+        table.insert("pre_install".to_owned(), profile.pre_install.clone().into());
+    }
+    if !profile.pre_remove.is_empty() {
+        table.insert("pre_remove".to_owned(), profile.pre_remove.clone().into());
+    }
+    if !profile.conditional_packages.is_empty() {
+        table.insert("conditional_packages".to_owned(), profile.conditional_packages.clone().into());
+    }
     if let Some(dev_name_pattern) = &profile.device_name_pattern {
         table.insert("device_name_pattern".to_owned(), dev_name_pattern.clone().into());
     }
@@ -437,10 +452,13 @@ mod tests {
             "nvidia-utils egl-wayland nvidia-settings opencl-nvidia lib32-opencl-nvidia \
              lib32-nvidia-utils libva-nvidia-driver vulkan-icd-loader lib32-vulkan-icd-loader"
         );
+        assert!(!parsed_profiles[0].conditional_packages.is_empty());
         assert_eq!(parsed_profiles[0].device_name_pattern, Some("(AD)\\w+".to_owned()));
         assert_eq!(parsed_profiles[0].hwd_ids, hwd_ids);
         assert!(!parsed_profiles[0].post_install.is_empty());
         assert!(!parsed_profiles[0].post_remove.is_empty());
+        assert!(!parsed_profiles[0].pre_install.is_empty());
+        assert!(!parsed_profiles[0].pre_remove.is_empty());
 
         assert_eq!(parsed_profiles[1].prof_path, prof_path);
         assert_eq!(parsed_profiles[1].name, "nvidia-dkms");
@@ -450,12 +468,15 @@ mod tests {
             "nvidia-utils egl-wayland nvidia-settings opencl-nvidia lib32-opencl-nvidia \
              lib32-nvidia-utils libva-nvidia-driver vulkan-icd-loader lib32-vulkan-icd-loader"
         );
+        assert!(!parsed_profiles[1].conditional_packages.is_empty());
         assert_eq!(parsed_profiles[1].device_name_pattern, None);
         assert_eq!(parsed_profiles[1].hwd_product_name_pattern, Some("(Ally)\\w+".to_owned()));
         assert_eq!(parsed_profiles[1].hwd_ids, hwd_ids);
         assert_eq!(parsed_profiles[1].gc_versions, None);
         assert!(!parsed_profiles[1].post_install.is_empty());
         assert!(!parsed_profiles[1].post_remove.is_empty());
+        assert!(!parsed_profiles[1].pre_install.is_empty());
+        assert!(!parsed_profiles[1].pre_remove.is_empty());
     }
 
     #[test]
@@ -488,11 +509,14 @@ mod tests {
             parsed_profiles[0].device_name_pattern,
             Some("((GM|GP)+[0-9]+[^M]*\\s.*)".to_owned())
         );
+        assert!(!parsed_profiles[0].conditional_packages.is_empty());
         assert_eq!(parsed_profiles[0].hwd_product_name_pattern, None);
         assert_eq!(parsed_profiles[0].hwd_ids, hwd_ids);
         assert_eq!(parsed_profiles[0].gc_versions, None);
         assert!(!parsed_profiles[0].post_install.is_empty());
         assert!(!parsed_profiles[0].post_remove.is_empty());
+        assert!(!parsed_profiles[0].pre_install.is_empty());
+        assert!(!parsed_profiles[0].pre_remove.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
I don't know how we missed it all this time, but anyway we should sync the profile scheme for Lua script and Rust part.

Fixes: https://github.com/CachyOS/chwd/issues/177