### PR TITLE
profiles/graphic_drivers: Skip open module if a closed one is already installed

### DIFF
--- a/profiles/pci/graphic_drivers/profiles.toml
+++ b/profiles/pci/graphic_drivers/profiles.toml
@@ -29,7 +29,7 @@ conditional_packages = """
 
     for kernel in $kernels; do
         case "$kernel" in
-            *-nvidia-open) modules+=" ${kernel}";;
+            *-nvidia-open|*-nvidia) modules+=" ${kernel}";;
             *-headers|*-zfs|*-nvidia|*-dbg);;
             *) packages+=" ${kernel}-nvidia-open";;
         esac


### PR DESCRIPTION
Since the closed profile has higher priority, it is installed first, but when installing an open profile for a different GPU, it causes a package conflict. So it's best to just skip installing open modules if there are already closed modules for the corresponding kernel.

Probably solves https://github.com/CachyOS/chwd/issues/158