### PR TITLE
profiles/handheld: Add support for Lenovo Legion Go S

### DIFF
--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -83,6 +83,15 @@ post_remove = """
     done
 """
 
+[amd-legion-go-s]
+desc = 'Lenovo Legion Go S'
+class_ids = "0300"
+vendor_ids = "1002"
+device_ids = "1681 15bf"
+hwd_product_name_pattern = '(83L3|83N6|83Q2|83Q3)'
+priority = 6
+packages = 'inputplumber steamos-manager steamos-powerbuttond cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+
 [intel-msi-claw]
 desc = 'MSI Claw Intel'
 class_ids = "0300"


### PR DESCRIPTION
This adds support for the Lenovo Legion Go S. This device comes with either a Phoenix APU or a Rembrandt APU. Hence, the profile name chosen is prefixed with `amd`, similar to what was done for the MSI Claw(s). Support in `inputplumber`, `steamos-manager` and `steamos-powerbuttond` is already available as this is an officialy supported device in SteamOS. The only remaining thing we need to add is the HID driver for this device, which has been added as of c4aab791b4c0e3747a62b6cf686dc5941e907938 and should arrive in 6.15.4.