### PR TITLE
profiles/handhelds: Install galileo-mura for Steam Deck OLED

### DIFF
--- a/profiles/pci/handhelds/profiles.toml
+++ b/profiles/pci/handhelds/profiles.toml
@@ -6,6 +6,11 @@ device_ids = "1435 163f"
 hwd_product_name_pattern = '(Jupiter|Galileo)'
 priority = 6
 packages = 'steamos-manager steamos-powerbuttond jupiter-fan-control steamdeck-dsp cachyos-handheld mesa lib32-mesa vulkan-radeon lib32-vulkan-radeon opencl-mesa lib32-opencl-mesa rocm-opencl-runtime'
+conditional_packages = """
+    if grep -q 'Galileo' /sys/devices/virtual/dmi/id/product_name; then
+        echo 'galileo-mura'
+    fi
+"""
 post_install = """
     echo "Steam Deck chwd installing..."
     services=("jupiter-fan-control")


### PR DESCRIPTION
This is used for mura compensation on the OLED Deck. The package is already available in repositories and the only thing pending is the kernel patch required to properly support this, which will be coming in 6.15.4.

Link: https://github.com/CachyOS/CachyOS-PKGBUILDS/issues/694