### PR TITLE
profiles: add tablet mode support for Framework Laptop 12

### DIFF
--- a/profiles/pci/framework/profiles.toml
+++ b/profiles/pci/framework/profiles.toml
@@ -1,0 +1,6 @@
+[framework-laptop-12]
+desc = 'Framework Laptop 12 tablet-mode sensor support'
+class_ids = '0601'
+hwd_product_name_pattern = '^Laptop 12 \(.*\)$'
+priority = 5
+packages = 'iio-sensor-proxy'


### PR DESCRIPTION
Detect Framework Laptop 12 models and install iio-sensor-proxy for accelerometer-based screen rotation in tablet mode.